### PR TITLE
[finishes #162178443] add geolocation functionality to the create rep…

### DIFF
--- a/ui/admin.html
+++ b/ui/admin.html
@@ -16,12 +16,12 @@
     </div>
     <div class="main">
       <div>
-         <a href="#all-cases"><button class="cases">All Cases</button></a>
-         <a href="#intervention-cases"><button class="cases">Corruption Cases</button></a>
-         <a href="#corruption-cases"><button class="cases">Intervention Cases</button></a>
+         <a href="#all-cases"><button class="cases">All Reports</button></a>
+         <a href="#intervention-reports"><button class="cases">Red Flag Reports</button></a>
+         <a href="#red-flag-reports"><button class="cases">Intervention Reports</button></a>
       </div>
-      <div class="options" id="corruption-cases">
-        <h3>All Corruption Cases</h3>
+      <div id="red-flag-reports">
+        <h3>All Red Flag Reports</h3>
         <table>
         	<thead>
           	<tr>
@@ -37,23 +37,20 @@
               <td><a class="show" href="./profile.html">ed</a></td>
           		<td>City Council bribery</td>
               <td class="date">22/11/2018</td>
-          		<td class="status">Accepted</td>
+          		<td class="status">Resolved</td>
               <td class="actions">
                 <a href="./admin.html"><button class="powers" id="reject">Reject</button></a>
-                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
-                <a href="./admin.html"><button class="powers" id="delete">Delete</button></a>
+                <a href="./admin.html"><button class="powers" id="investigate">Investigate</button></a>
               </td>
           	</tr>
           	<tr>
               <td><a class="show" href="./profile.html">ed</a></td>
           		<td>Tender corruption</td>
               <td class="date">22/11/2018</td>
-          		<td class="status">Pending</td>
+          		<td class="status">Under Investigation</td>
               <td class="actions">
-                <a href="./admin.html"><button class="powers" id="accept">Accept</button></a>
+                <a href="./admin.html"><button class="powers" id="resolve">Resolve</button></a>
                 <a href="./admin.html"><button class="powers" id="reject">Reject</button></a>
-                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
-                <a href="./admin.html"><button class="powers" id="delete">Delete</button></a>
               </td>
           	</tr>
             <tr>
@@ -62,16 +59,15 @@
               <td class="date">22/11/2018</td>
           		<td class="status">Rejected</td>
               <td class="actions">
-                <a href="./admin.html"><button class="powers" id="accept">Accept</button></a>
-                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
-                <a href="./admin.html"><button class="powers" id="delete">Delete</button></a>
+                <a href="./admin.html"><button class="powers" id="resolve">Resolve</button></a>
+                <a href="./admin.html"><button class="powers" id="investigate">Investigate</button></a>
               </td>
           	</tr>
         	</tbody>
         </table>
       </div>
-      <div class="options" id="intervention-cases">
-        <h3>All Intervention Cases</h3>
+      <div id="intervention-reports">
+        <h3>All Intervention Reports</h3>
         <table>
         	<thead>
           	<tr>
@@ -87,23 +83,20 @@
               <td><a class="show" href="./profile.html">ed</a></td>
           		<td><a  class="show" href="./report.html">Budalangi floods</a></td>
               <td class="date">22/11/2018</td>
-          		<td class="status">Accepted</td>
+          		<td class="status">Resolved</td>
               <td class="actions">
                 <a href="./admin.html"><button class="powers" id="reject">Reject</button></a>
-                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
-                <a href="./admin.html"><button class="powers" id="delete">Delete</button></a>
+                <a href="./admin.html"><button class="powers" id="investigate">Investigate</button></a>
               </td>
           	</tr>
           	<tr>
               <td><a class="show" href="./profile.html">ed</a></td>
           		<td>Huruma building collapse</td>
               <td class="date">22/11/2018</td>
-          		<td class="status">Pending</td>
+          		<td class="status">Under Investigation</td>
               <td class="actions">
-                <a href="./admin.html"><button class="powers" id="accept">Accept</button></a>
+                <a href="./admin.html"><button class="powers" id="resolve">Resolve</button></a>
                 <a href="./admin.html"><button class="powers" id="reject">Reject</button></a>
-                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
-                <a href="./admin.html"><button class="powers" id="delete">Delete</button></a>
               </td>
           	</tr>
             <tr>
@@ -112,9 +105,8 @@
               <td class="date">22/11/2018</td>
           		<td class="status">Rejected</td>
               <td class="actions">
-                <a href="./admin.html"><button class="powers" id="accept">Accept</button></a>
-                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
-                <a href="./admin.html"><button class="powers" id="delete">Delete</button></a>
+                <a href="./admin.html"><button class="powers" id="resolve">Resolve</button></a>
+                <a href="./admin.html"><button class="powers" id="investigate">Investigate</button></a>
               </td>
           	</tr>
         	</tbody>

--- a/ui/create-report.html
+++ b/ui/create-report.html
@@ -5,6 +5,7 @@
     <title>iReporter | New Report</title>
     <link rel="stylesheet" href="styles.css"></link>
     <link href="https://fonts.googleapis.com/css?family=Mina" rel="stylesheet">
+    <script type="text/javascript" src="./script.js"></script>
   </head>
   <body>
     <div class="topnav">
@@ -21,15 +22,18 @@
        <form action="./profile.html" class="report-form">
          <label for="report-type"><b>Type of Report</b></label><br/>
          <select name="report-type">
-           <option value="Corruption Report">Corruption Report</option>
-           <option value="Intervention quest">Intervention Request</option>
+           <option value="Corruption Report">Red Flag Report</option>
+           <option value="Intervention quest">Intervention Report</option>
          </select><br/>
          <label for="title"><b>Title</b></label>
          <input type="text" class="information" name="title">
          <label for="description"><b>Description</b></label>
          <textarea rows="8" cols="80" class="information" name="description"></textarea>
-         <label for="upload"><b>Upload Attachment</b></label>
-         <input type="file" class="information" name="upload">
+         <label for="location"><b>Location</b></label><input type="button" id="get-location" value="Get My Location" onclick="getLocationConstant()"><br/>
+         <label for="location" class="geolocation"><b>Latitude</b></label><input type="text" class="location" name="latitude" id="latitude">
+         <label for="location" class="geolocation"><b>Longitude</b></label><input type="text" class="location" name="longitude" id="longitude"><br/>
+         <label for="upload"><b>Media</b></label><br/>
+         <input type="file" name="upload" class="upload"><br/>
          <label for="password"><b>Password</b></label>
          <input type="password" class="information" name="password">
          <button type="submit" class="submit">Submit Report</button>

--- a/ui/edit-report.html
+++ b/ui/edit-report.html
@@ -5,6 +5,7 @@
     <title>iReporter | Edit Report</title>
     <link rel="stylesheet" href="styles.css"></link>
     <link href="https://fonts.googleapis.com/css?family=Mina" rel="stylesheet">
+    <script type="text/javascript" src="./script.js"></script>
   </head>
   <body>
     <div class="topnav">
@@ -21,13 +22,18 @@
        <form action="./profile.html">
          <label for="report-type"><b>Type of Report</b></label><br/>
          <select name="report-type">
-           <option value="Corruption Report">Corruption Report</option>
-           <option value="Intervention quest">Intervention Request</option>
+           <option value="Corruption Report">Red Flag Report</option>
+           <option value="Intervention quest">Intervention Report</option>
          </select><br/>
          <label for="title"><b>Title</b></label>
          <input type="text" class="information" name="title">
          <label for="description"><b>Description</b></label>
          <textarea rows="8" cols="80" class="information" name="description"></textarea>
+         <label for="upload"><b>Location</b></label><input type="button" id="get-location" value="Get My Location" onclick="getLocationConstant()"><br/>
+         <label for="location" class="geolocation"><b>Latitude</b></label><input class="location" name="location" id="latitude">
+         <label for="location" class="geolocation"><b>Longitude</b></label><input class="location" name="location" id="longitude"><br/>
+         <label for="upload"><b>Media</b></label>
+         <input type="file" name="upload" class="upload"><br/>
          <label for="password"><b>Password</b></label>
          <input type="password" class="information" name="password">
          <button type="submit" class="submit">Update Report</button>

--- a/ui/profile.html
+++ b/ui/profile.html
@@ -17,12 +17,12 @@
     </div>
     <div class="main">
       <div>
-         <a href="#all-cases"><button class="cases">All Cases</button></a>
-         <a href="#intervention-cases"><button class="cases">Corruption Cases</button></a>
-         <a href="#corruption-cases"><button class="cases">Intervention Cases</button></a>
+         <a href="#all-cases"><button class="cases">All Reports</button></a>
+         <a href="#intervention-reports"><button class="cases">Red Flag Reports</button></a>
+         <a href="#red-flag-reports"><button class="cases">Intervention Reports</button></a>
       </div>
-      <div class="options" id="corruption-cases">
-        <h3>My Corruption Cases</h3>
+      <div id="red-flag-reports">
+          <h3>My Red Flag Reports</h3>
         <table>
           <thead>
             <tr>
@@ -36,26 +36,35 @@
             <tr>
               <td>City Council bribery</td>
               <td class="date">22/11/2018</td>
-              <td class="status">Accepted</td>
-              <td class="actions"><a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a><a href="./profile.html"><button class="powers" id="delete">Delete</button></a></td>
+              <td class="status">Resolved</td>
+              <td class="actions">
+                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
+                <a href="./profile.html"><button class="powers" id="delete">Delete</button></a>
+              </td>
             </tr>
             <tr>
               <td>Tender corruption</td>
               <td class="date">22/11/2018</td>
-              <td class="status">Pending</td>
-              <td class="actions"><a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a><a href="./profile.html"><button class="powers" id="delete">Delete</button></a></td>
+              <td class="status">Under Investigation</td>
+              <td class="actions">
+                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
+                <a href="./profile.html"><button class="powers" id="delete">Delete</button></a>
+              </td>
             </tr>
             <tr>
               <td>Traffic police corruption</td>
               <td class="date">22/11/2018</td>
               <td class="status">Rejected</td>
-              <td class="actions"><a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a><a href="./profile.html"><button class="powers" id="delete">Delete</button></a></td>
+              <td class="actions">
+                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
+                <a href="./profile.html"><button class="powers" id="delete">Delete</button></a>
+              </td>
             </tr>
           </tbody>
         </table>
       </div>
-      <div class="options" id="intervention-cases">
-        <h3>My Intervention Cases</h3>
+      <div id="intervention-reports">
+        <h3>My Intervention Reports</h3>
         <table>
           <thead>
             <tr>
@@ -69,20 +78,29 @@
             <tr>
               <td><a class="show" href="./report.html">Budalangi floods</a></td>
               <td class="date">22/11/2018</td>
-              <td class="status">Accepted</td>
-              <td class="actions"><a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a><a href="./profile.html"><button class="powers" id="delete">Delete</button></a></td>
+              <td class="status">Resolved</td>
+              <td class="actions">
+                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
+                <a href="./profile.html"><button class="powers" id="delete">Delete</button></a>
+              </td>
             </tr>
             <tr>
               <td>Huruma building collapse</td>
               <td class="date">22/11/2018</td>
-              <td class="status">Pending</td>
-              <td class="actions"><a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a><a href="./profile.html"><button class="powers" id="delete">Delete</button></a></td>
+              <td class="status">Under Investigation</td>
+              <td class="actions">
+                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
+                <a href="./profile.html"><button class="powers" id="delete">Delete</button></a>
+              </td>
             </tr>
             <tr>
               <td>Pumwani hospital understocked</td>
               <td class="date">22/11/2018</td>
               <td class="status">Rejected</td>
-              <td class="actions"><a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a><a href="./profile.html"><button class="powers" id="delete">Delete</button></a></td>
+              <td class="actions">
+                <a href="./edit-report.html"><button class="powers" id="edit">Edit</button></a>
+                <a href="./profile.html"><button class="powers" id="delete">Delete</button></a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/ui/report.html
+++ b/ui/report.html
@@ -18,8 +18,10 @@
     <div class="main">
       <div id="report-story">
         <h2>Budalangi Floods</h2>
-        <h3>by <a href="./profile.html">ed</a></h3>
+        <h3>by <a class="show" href="./profile.html">ed</a></h3>
         <div id="report-description">
+          <p><b>Location</b>: Budalangi</p>
+          <p><b>Type of Report</b>: Intervention Report</p>
           <p>I am a resident of budalangi. I, along with many of my neighbours, have lost our homes due to floods.</p>
           <p>We are requesting that the government provide the following.</p>
           <ul>

--- a/ui/script.js
+++ b/ui/script.js
@@ -1,0 +1,16 @@
+function getLocationConstant() {
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(onGeoSuccess, onGeoError);
+  } else {
+    alert("Your browser or device doesn't support Geolocation");
+  }
+}
+
+function onGeoSuccess(event) {
+  document.getElementById("latitude").value = event.coords.latitude;
+  document.getElementById('longitude').value = event.coords.longitude;
+}
+
+function onGeoError(event) {
+  alert("Error code " + event.code + ". " + event.message);
+}

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -2,12 +2,12 @@ html, body {
   height: 100%;
   margin: 0;
 }
+h1, h3 {
+  font-family: 'Mina';
+}
 a {
   text-decoration: none;
   color: white;
-}
-h1, h3 {
-  font-family: 'Mina';
 }
 img {
   width: 300px;
@@ -24,6 +24,9 @@ button {
   border: none;
   color: white;
 }
+select {
+  margin: 5px 0px 15px 0px;
+}
 table {
   border-collapse: collapse;
   width: 100%;
@@ -35,12 +38,20 @@ th {
 th, td {
   border: 3px solid black;
   font-size: 20px;
+  padding: 3px;
 }
 tbody {
   text-align: left;
 }
 tbody tr:nth-of-type(odd) {
 	background: #eee;
+}
+.main {
+  padding: 20px;
+  min-height: 100%;
+  margin: 10vh auto 0;
+  text-align: center;
+  width: 1200px;
 }
 .topnav {
   background-color: #000;
@@ -59,16 +70,74 @@ tbody tr:nth-of-type(odd) {
 .topnav-right {
   float: right;
 }
-.main {
-  text-align: center;
-  position: absolute;
-  margin: auto;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 1200px;
-  height: 80%;
+.notice {
+  color: white;
+}
+.cases {
+  width: 200px;
+  height: 60px;
+  background-color: blue;
+  margin: 5px;
+  font-size: 20px;
+}
+.container {
+  border-radius: 5px;
+  background-color: #595959;
+  padding: 10px;
+  width: 50%;
+  display: inline-block;
+}
+.information {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  margin-top: 6px;
+  margin-bottom: 16px;
+  resize: vertical
+}
+.location {
+  width: 30%;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin: 10px;
+}
+.geolocation {
+  text-align: left;
+  font-size: 15px;
+  margin: 2px;
+}
+.upload {
+  margin: 10px;
+}
+.report {
+  background-color: green;
+  width: 200px;
+  height: 60px;
+  font-size: 25px;
+  font-family: monospace;
+  margin: 5px;
+}
+.date, .status {
+  width: 10%;
+}
+.actions {
+  width: 25%;
+}
+.powers {
+  width: 75px;
+  height: 50px;
+  margin: 5px;
+}
+.reporter {
+  width: 15%;
+}
+.show {
+  color: black;
+}
+.show:hover {
+  text-decoration: underline;
 }
 .row {
   display: table;
@@ -79,39 +148,6 @@ tbody tr:nth-of-type(odd) {
   float: left;
   width: 350px;
 }
-@media only screen and (max-width: 1200px) {
-    .main, .column {
-      width: 100%;
-    }
-    .row {
-      margin-left: 10%;
-    }
-}
-.container {
-  border-radius: 5px;
-  background-color: #595959;
-  padding: 10px;
-  width: 50%;
-  display: inline-block;
-}
-.information {
-    width: 100%;
-    padding: 12px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    box-sizing: border-box;
-    margin-top: 6px;
-    margin-bottom: 16px;
-    resize: vertical
-}
-.report {
-  background-color: green;
-  width: 200px;
-  height: 60px;
-  font-size: 25px;
-  font-family: monospace;
-  margin: 5px;
-}
 .submit {
   border: none;
   background-color: green;
@@ -119,65 +155,45 @@ tbody tr:nth-of-type(odd) {
   height: 30px;
   font-size: 20px;
 }
-.notice {
+#get-location {
+  background-color: #ff9900;
+  margin: 2px;
+  width: 160px;
+  height: 30px;
+  border-radius: 4px;
+  border: none;
+  font-size: 20px;
   color: white;
 }
-.powers {
-  width: 50px;
-  height: 50px;
-  margin: 5px;
+#red-flag-reports:target {
+  display: none;
 }
-.cases {
-  width: 200px;
-  height: 60px;
-  background-color: blue;
-  margin: 5px;
+#intervention-reports:target {
+  display: none;
 }
-.cases {
-  font-size: 20px;
-}
-#accept {
+#resolve {
   background-color: green;
 }
-#reject {
-  background-color: brown;
-}
-#edit {
-  background-color: orange;
-}
-#delete {
+#reject, #delete {
   background-color: red;
 }
-#corruption-cases:target {
-  display: none;
-}
-#intervention-cases:target {
-  display: none;
-}
-select {
-  margin: 5px 0px 15px 0px;
-}
-.date, .status {
-  width: 10%;
-}
-.actions {
-  width: 25%;
-}
-.reporter {
-  width: 15%;
-}
-.show {
-  color: black;
+#investigate, #edit {
+  background-color: orange;
 }
 #report-description {
   text-align: left;
 }
 #report-story {
-  background-color: #80ffff;
+  background-color: #cccccc;
 }
 #report-description {
   font-size: 20px;
 }
-#report-story a {
-  color: purple;
+@media only screen and (max-width: 1200px) {
+    .main, .column {
+      width: 100%;
+    }
+    .row {
+      margin-left: 10%;
+    }
 }


### PR DESCRIPTION
__What does this PR do?__
Add geolocation functionality to the create report and edit report forms in the create report and edit report pages respectively.

__Description of tasks to be completed.__
On both the create report and the edit report page forms, add a 'Get My Location' button which, when a user clicks, will auto fill the latitude and longitude input fields with the latitude and longitude respectively.

__How should it be manually tested?__
Clone the project. Check out the ft-add-geolocation-#162178443 branch. Open the ui folder and run the create-report.html and the edit-report.html files using a browser.

__Relevant pivotal tracker stories.__
#162178443

__Relevant screenshots.__
![create report form](https://user-images.githubusercontent.com/20911240/48969793-b155c300-f014-11e8-979d-95c171cd5ff6.png)
![edit report form](https://user-images.githubusercontent.com/20911240/48969794-b450b380-f014-11e8-9598-b8eb84abe75d.png)
