### PR TITLE
[finishes #162216975] create a get a specific red flag endpoint

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,9 +1,10 @@
 from flask import Blueprint
 from flask_restful import Api, Resource
 
-from .views import RedFlags
+from .views import RedFlags, RedFlag
 
 version_one = Blueprint('api_v1', __name__, url_prefix='/api/v1')
 api = Api(version_one)
 
 api.add_resource(RedFlags, '/red-flags')
+api.add_resource(RedFlag, '/red-flag/<id>')

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -11,3 +11,14 @@ class RedFlags(Resource):
 
     def get(self):
         return make_response(jsonify({"status": 200, "data": self.red_flags.db}))
+
+class RedFlag(Resource):
+    def __init__(self):
+        self.red_flags = RedFlagsModel()
+
+    def get(self, id):
+        red_flag = next(filter(lambda x: x["id"] == int(id), self.red_flags.db), None)
+        if red_flag:
+            return make_response(jsonify({"status": 200, "data": [red_flag]}))
+        else:
+            return make_response(jsonify({"status": 404, "error": "Red-flag record not found"}), 404)

--- a/app/tests/v1/test_red_flags.py
+++ b/app/tests/v1/test_red_flags.py
@@ -22,3 +22,17 @@ class TestRedFlags(TestCase):
         data = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data, {"status": 200, "data": self.red_flags.db})
+
+    def test_get_specific_red_flag(self):
+        """This test ensures that the api endpoint gets a specific red-flag record"""
+        response = self.app.get('/api/v1/red-flag/1')
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data, {"status": 200, "data": [self.red_flags.db[0]]})
+
+    def test_red_flag_not_found(self):
+        """This test ensures that when a specific red-flag record does not exist, we get an error message saying record not found."""
+        response1 = self.app.get('/api/v1/red-flag/0')
+        data1 = json.loads(response1.data)
+        self.assertEqual(response1.status_code, 404)
+        self.assertEqual(data1, {"status": 404, "error": "Red-flag record not found"})


### PR DESCRIPTION
__What does this PR do?__
Create a get specific red-flag api endpoint.

__Description of tasks to be completed.__
Create an api endpoint to get a specific red-flag.

__How should it be manually tested?__
Clone the project. Check out the ft-create-get-a-specific-red-flag-endpoint-#162216975 branch. Start the environment using env\Scripts\activate. Run flask run on the terminal and go to Postman. To perform the tests run nose2.

__Relevant pivotal tracker stories.__
#162216975