### PR TITLE
[finishes #162217302] create a delete a specific red flag endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
 .pytest_cache
+.env
+.vscode/
 .coverage
-env

--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -38,3 +38,6 @@ class RedFlagsModel():
 
     def save(self, new_red_flag):
         self.db.append(new_red_flag)
+
+    def remove(self, red_flag_id):
+        self.db = list(filter(lambda x: x["id"] != int(red_flag_id), self.db))

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -40,6 +40,14 @@ class RedFlag(Resource):
         else:
             return make_response(jsonify({"status": 404, "error": "Red-flag record not found"}), 404)
 
+    def delete(self, id):
+        red_flag = next(filter(lambda x: x["id"] == int(id), self.red_flags.db), None)
+        if red_flag:
+            self.red_flags.remove(id)
+            return make_response(jsonify({"status": 200,"data": [{"id": int(id), "message": "Red-flag record has been deleted"}]}))
+        else:
+            return make_response(jsonify({"status": 404, "error": "Red-flag record not found"}), 404)
+
 class PatchLocation(Resource):
     def __init__(self):
         self.red_flags = RedFlagsModel()

--- a/app/tests/v1/test_red_flags.py
+++ b/app/tests/v1/test_red_flags.py
@@ -65,10 +65,17 @@ class TestRedFlags(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data, {"status": 200, "data": [{"id": 1, "message": "Updated red-flag record's comment"}]})
 
+    def test_delete_a_specific_red_flag(self):
+        """This test ensures that the api endpoint deletes a specific red-flag record"""
+        response = self.app.delete('/api/v1/red-flag/1')
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data, {"status": 200, "data": [{"id": 1, "message": "Red-flag record has been deleted"}]})
+
     def test_red_flag_not_found(self):
         """This test ensures that when a specific red-flag record does not exist, we get an error message saying record not found.
-        This test covers all 3 scenarios where we need a specific record: when getting a specific record, when changing a specific
-        record's location and when changing a specific record's comment respectively"""
+        This test covers all 4 scenarios where we need a specific record: when getting a specific record, when changing a specific
+        record's location, when changing a specific record's comment and when deleting a specific record respectively"""
         response1 = self.app.get('/api/v1/red-flag/0')
         data1 = json.loads(response1.data)
         self.assertEqual(response1.status_code, 404)
@@ -83,3 +90,8 @@ class TestRedFlags(TestCase):
         data3 = json.loads(response3.data)
         self.assertEqual(response3.status_code, 404)
         self.assertEqual(data3, {"status": 404, "error": "Red-flag record not found"})
+
+        response4 = self.app.delete('/api/v1/red-flag/0')
+        data4 = json.loads(response4.data)
+        self.assertEqual(response4.status_code, 404)
+        self.assertEqual(data4, {"status": 404, "error": "Red-flag record not found"})


### PR DESCRIPTION
__What does this PR do?__
Create a delete specific red-flag api endpoint.

__Description of tasks to be completed.__
Create an api endpoint to delete a specific red-flag.

__How should it be manually tested?__
Clone the project. Check out the ft-create-a-delete-a-specific-red-flag-endpoint-#162217302 branch. Start the environment using env\Scripts\activate. Run flask run on the terminal and go to Postman. To perform the tests run nose2.

__Relevant pivotal tracker stories.__
#162217302