### PR TITLE
[finishes #162364311] fit edit red-flag endpoint

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,12 +1,11 @@
 from flask import Blueprint
 from flask_restful import Api, Resource
 
-from .views import RedFlags, RedFlag, EditLocation, EditComment
+from .views import RedFlags, RedFlag, EditRedFlag
 
 version_one = Blueprint('api_v1', __name__, url_prefix='/api/v1')
 api = Api(version_one)
 
 api.add_resource(RedFlags, '/red-flags')
 api.add_resource(RedFlag, '/red-flags/<id>')
-api.add_resource(EditLocation, '/red-flags/<id>/location')
-api.add_resource(EditComment, '/red-flags/<id>/comment')
+api.add_resource(EditRedFlag, '/red-flags/<id>/<key>')

--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -25,9 +25,18 @@ red_flags = [
         "location": "3,3",
         "status": "Rejected",
         "comment": "Hurry!"
+    },
+    {
+        "id": 4,
+        "createdOn": "28-11-2018 09:57",
+        "createdBy": 4,
+        "type": "Red Flag Report",
+        "location": "4,4",
+        "status": "Draft",
+        "comment": "Not too urgent!"
     }
 ]
-total_red_flags_ever = 3
+total_red_flags_ever = 4
 
 class RedFlagsModel():
     def __init__(self):
@@ -44,8 +53,7 @@ class RedFlagsModel():
         self.db.append(new_red_flag)
 
     def edit(self, red_flag, new_data):
-        edited_red_flag = red_flag.update(new_data)
-        return edited_red_flag
+        red_flag.update(new_data)
 
-    def remove(self, red_flag_id):
+    def delete(self, red_flag_id):
         self.db = list(filter(lambda x: x["id"] != int(red_flag_id), self.db))

--- a/app/tests/v1/test_red_flags.py
+++ b/app/tests/v1/test_red_flags.py
@@ -13,12 +13,12 @@ class TestRedFlags(TestCase):
         self.app.testing = True
         self.red_flags = RedFlagsModel()
         self.new_red_flag = {
-            "id": 4,
-            "createdOn":"27-11-2018 09:57",
-            "createdBy": 4,
+            "id": 5,
+            "createdOn":"29-11-2018 09:57",
+            "createdBy": 5,
             "type": "Red Flag Report",
-            "location": "4,4",
-            "status": "In Draft",
+            "location": "5,5",
+            "status": "Draft",
             "comment": "Undetermined"
         }
         self.new_location = {
@@ -27,6 +27,7 @@ class TestRedFlags(TestCase):
         self.new_comment = {
             "comment": "It was a prank"
         }
+
 
     def tearDown(self):
         self.red_flags = None
@@ -50,48 +51,79 @@ class TestRedFlags(TestCase):
         response = self.app.post('/api/v1/red-flags', data = json.dumps(self.new_red_flag), content_type = "application/json")
         data = json.loads(response.data)
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(data, {"status": 201, "data": [{"id": 4,"message": "Created red-flag report"}]})
+        self.assertEqual(data, {"status": 201, "data": [{"id": 5,"message": "Created red-flag report"}]})
 
     def test_edit_a_specific_red_flag(self):
         """This test ensures that the api endpoint edits a specific red-flag. This test covers 2 scenarios: changing the location
         and changing the comment of a red-flag respectively"""
-        response1 = self.app.patch('/api/v1/red-flags/1/location', data = json.dumps(self.new_location), content_type = "application/json")
-        data1 = json.loads(response1.data)
-        self.assertEqual(response1.status_code, 200)
-        self.assertEqual(data1, {"status": 200, "data": [{"id": 1, "message": "Updated red-flag record's location"}]})
+        response_1 = self.app.patch('/api/v1/red-flags/4/location', data = json.dumps(self.new_location), content_type = "application/json")
+        data_1 = json.loads(response_1.data)
+        self.assertEqual(response_1.status_code, 200)
+        self.assertEqual(data_1, {"status": 200, "data": [{"id": 4, "message": "Updated red-flag record's location"}]})
 
-        response2 = self.app.patch('/api/v1/red-flags/1/comment', data = json.dumps(self.new_comment), content_type = "application/json")
-        data2 = json.loads(response2.data)
-        self.assertEqual(response2.status_code, 200)
-        self.assertEqual(data2, {"status": 200, "data": [{"id": 1, "message": "Updated red-flag record's comment"}]})
+        response_2 = self.app.patch('/api/v1/red-flags/4/comment', data = json.dumps(self.new_comment), content_type = "application/json")
+        data_2 = json.loads(response_2.data)
+        self.assertEqual(response_2.status_code, 200)
+        self.assertEqual(data_2, {"status": 200, "data": [{"id": 4, "message": "Updated red-flag record's comment"}]})
+
+    def test_wrong_key_to_edit(self):
+        """This test ensures that you can only edit the comment or location of a red_flag record. There are 2 scenarios to test:
+        one where there is an attempt to edit a key that doesn't exist in a red_flag and the other where the key exists but is
+        neither location or comment"""
+        response_1 = self.app.patch('/api/v1/red-flags/4/description')
+        data_1 = json.loads(response_1.data)
+        self.assertEqual(response_1.status_code, 400)
+        self.assertEqual(data_1, {"status": 400, "error": "This red-flag report does not have a description, and hence cannot be edited."})
+
+        response_2 = self.app.patch('/api/v1/red-flags/4/id')
+        data_2 = json.loads(response_2.data)
+        self.assertEqual(response_2.status_code, 403)
+        self.assertEqual(data_2, {"status": 403, "error": "You are not allowed to edit this Red-flag record's id."})
 
     def test_delete_a_specific_red_flag(self):
         """This test ensures that the api endpoint deletes a specific red-flag record"""
-        response = self.app.delete('/api/v1/red-flags/1')
+        response = self.app.delete('/api/v1/red-flags/4')
         data = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data, {"status": 200, "data": [{"id": 1, "message": "Red-flag record has been deleted"}]})
+        self.assertEqual(data, {"status": 200, "data": [{"id": 4, "message": "Red-flag record has been deleted"}]})
+
+    def test_cannot_edit_or_delete_red_flag_not_in_draft(self):
+        """This test ensures that the api endpoint cannot edit or delete a red-flag record if it's status is not 'Draft'"""
+        response_1 = self.app.patch('/api/v1/red-flags/1/location')
+        data_1 = json.loads(response_1.data)
+        self.assertEqual(response_1.status_code, 200)
+        self.assertEqual(data_1, {"status": 200, "error": "Red-flag record cannot be edited because it has already been submitted for investigation."})
+
+        response_2 = self.app.patch('/api/v1/red-flags/1/comment')
+        data_2 = json.loads(response_2.data)
+        self.assertEqual(response_2.status_code, 200)
+        self.assertEqual(data_2, {"status": 200, "error": "Red-flag record cannot be edited because it has already been submitted for investigation."})
+
+        response_3 = self.app.delete('/api/v1/red-flags/1')
+        data_3 = json.loads(response_3.data)
+        self.assertEqual(response_3.status_code, 200)
+        self.assertEqual(data_3, {"status": 200, "error": "Red-flag record cannot be deleted because it has already been submitted for investigation."})
 
     def test_red_flag_not_found(self):
         """This test ensures that when a specific red-flag record does not exist, we get an error message saying record not found.
         This test covers all 4 scenarios where we need a specific record: when getting a specific record, when changing a specific
         record's location, when changing a specific record's comment and when deleting a specific record respectively"""
-        response1 = self.app.get('/api/v1/red-flags/0')
-        data1 = json.loads(response1.data)
-        self.assertEqual(response1.status_code, 404)
-        self.assertEqual(data1, {"status": 404, "error": "Red-flag record not found"})
+        response_1 = self.app.get('/api/v1/red-flags/0')
+        data_1 = json.loads(response_1.data)
+        self.assertEqual(response_1.status_code, 404)
+        self.assertEqual(data_1, {"status": 404, "error": "Red-flag record not found"})
 
-        response2 = self.app.patch('/api/v1/red-flags/0/location')
-        data2 = json.loads(response2.data)
-        self.assertEqual(response2.status_code, 404)
-        self.assertEqual(data2, {"status": 404, "error": "Red-flag record not found"})
+        response_2 = self.app.patch('/api/v1/red-flags/0/location')
+        data_2 = json.loads(response_2.data)
+        self.assertEqual(response_2.status_code, 404)
+        self.assertEqual(data_2, {"status": 404, "error": "Red-flag record not found"})
 
-        response3 = self.app.patch('/api/v1/red-flags/0/comment')
-        data3 = json.loads(response3.data)
-        self.assertEqual(response3.status_code, 404)
-        self.assertEqual(data3, {"status": 404, "error": "Red-flag record not found"})
+        response_3 = self.app.patch('/api/v1/red-flags/0/comment')
+        data_3 = json.loads(response_3.data)
+        self.assertEqual(response_3.status_code, 404)
+        self.assertEqual(data_3, {"status": 404, "error": "Red-flag record not found"})
 
-        response4 = self.app.delete('/api/v1/red-flags/0')
-        data4 = json.loads(response4.data)
-        self.assertEqual(response4.status_code, 404)
-        self.assertEqual(data4, {"status": 404, "error": "Red-flag record not found"})
+        response_4 = self.app.delete('/api/v1/red-flags/0')
+        data_4 = json.loads(response_4.data)
+        self.assertEqual(response_4.status_code, 404)
+        self.assertEqual(data_4, {"status": 404, "error": "Red-flag record not found"})


### PR DESCRIPTION
__What does this PR do?__
Fix the edit red-flag endpoint

__Description of tasks to be completed.__
delete PatchLocation and PatchComment classes in views.py and replace them with EditRedFlag
delete api endpoints for PatchComment and PatchLocation and replace them with one endpoint for EditRedFlag
create tests for when wrong key is entered in the EditRedFlag endpoint

__How should it be manually tested?__
Clone the project. Check out the bg-fix-edit-red-flag-endpoint#162364311 branch. Start the environment using env\Scripts\activate. Run flask run on the terminal and go to Postman. To perform the tests run nosetest.

__Relevant pivotal tracker stories.__
#162364311